### PR TITLE
Add storage allocation parameters to R#nc_create

### DIFF
--- a/src/ncdf2.c
+++ b/src/ncdf2.c
@@ -23,6 +23,16 @@ void R_nc4_enddef( int *ncid )
 }
 
 /*********************************************************************/
+void R_nc4__enddef( int *ncid, int *h_minfree, int *v_align, int *v_minfree, int *r_align)
+{
+	int	err;
+	err = nc__enddef(*ncid, *h_minfree, *v_align, *v_minfree, *r_align);
+	if( err != NC_NOERR )
+		Rprintf( "Error in R_nc4__enddef: %s\n",
+			nc_strerror(err) );
+}
+
+/*********************************************************************/
 void R_nc4_sync( int *ncid )
 {
 	int	err;


### PR DESCRIPTION
These are the same parameters taken by the native NetCDF4 function nc__enddef, giving contol over how storage is allocated for various sections in the file.

R#nc_create now calls (through a couple of intermediate functions) nc__enddef with those params (instead of nc_enddef, without them) as it finishes creating the file.